### PR TITLE
add object_warn mock

### DIFF
--- a/c74_mock_misc.h
+++ b/c74_mock_misc.h
@@ -39,6 +39,18 @@ namespace c74 {
 		std::cout << msg;
 	}
 
+	MOCK_EXPORT void object_post(void*, const char* fmt, ...) {
+		char msg[2048 + 2];
+		va_list ap;
+
+		va_start(ap, fmt);
+		vsnprintf(msg, 2048, fmt, ap);
+		va_end(ap);
+		msg[2048] = '\0';
+		//printf(msg);
+		std::cout << msg;
+	}
+
 
 	MOCK_EXPORT void object_error(void*, const char* fmt, ...) {
 		char msg[2048 + 2];

--- a/c74_mock_misc.h
+++ b/c74_mock_misc.h
@@ -39,7 +39,7 @@ namespace c74 {
 		std::cout << msg;
 	}
 
-	MOCK_EXPORT void object_post(void*, const char* fmt, ...) {
+	MOCK_EXPORT void object_warn(void*, const char* fmt, ...) {
 		char msg[2048 + 2];
 		va_list ap;
 


### PR DESCRIPTION
This is required for the [min-devkit](https://github.com/Cycling74/min-devkit) to build without errors when merging Cycling74/min-api#129