### PR TITLE
Make now() return a steady_clock time_point

### DIFF
--- a/c74_mock_clock.h
+++ b/c74_mock_clock.h
@@ -90,7 +90,7 @@ namespace mock {
         }
 
         auto now() {
-            return std::chrono::high_resolution_clock::now();
+            return std::chrono::steady_clock::now();
         }
 
         void tick() {


### PR DESCRIPTION
In tick(), we compare an event's onset (timepoint) with now(). However, these were using different clocks which resulted in compile errors with some compilers